### PR TITLE
[FE] Design: 일반모임통장 모임종류 및 모임원 추가, 해외여행 올인원 모임통장 개설 안내 화면, 외화모임통장 개설 화면 디자인

### DIFF
--- a/frontend/soltravel/.gitignore
+++ b/frontend/soltravel/.gitignore
@@ -17,6 +17,7 @@
 .env.development.local
 .env.test.local
 .env.production.local
+.env
 
 npm-debug.log*
 yarn-debug.log*

--- a/frontend/soltravel/package-lock.json
+++ b/frontend/soltravel/package-lock.json
@@ -11,6 +11,7 @@
         "@emotion/react": "^11.13.0",
         "@emotion/styled": "^11.13.0",
         "@mui/material": "^5.16.7",
+        "@mui/x-charts": "^7.14.0",
         "@reduxjs/toolkit": "^2.2.7",
         "@testing-library/jest-dom": "^5.17.0",
         "@testing-library/react": "^13.4.0",
@@ -3564,6 +3565,63 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="
     },
+    "node_modules/@mui/x-charts": {
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/@mui/x-charts/-/x-charts-7.14.0.tgz",
+      "integrity": "sha512-yjBEGk9fl7rMnCaTqibQEf2Dq8oVMzMVDkEXOztJbb8XG+iC/EtRPOWRahgFVi5xitiKR+lLJ/ezBWzuYK739A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.25.0",
+        "@mui/system": "^5.16.7",
+        "@mui/utils": "^5.16.6",
+        "@mui/x-charts-vendor": "7.14.0",
+        "@react-spring/rafz": "^9.7.4",
+        "@react-spring/web": "^9.7.4",
+        "clsx": "^2.1.1",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.9.0",
+        "@emotion/styled": "^11.8.1",
+        "@mui/material": "^5.15.14",
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/react": {
+          "optional": true
+        },
+        "@emotion/styled": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/x-charts-vendor": {
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/@mui/x-charts-vendor/-/x-charts-vendor-7.14.0.tgz",
+      "integrity": "sha512-hhEwqQ5Gt2uEFCIna7OPycyu/CzVlywmH5SIX9O3Rxe/y0muLhafEX2ooOQpopcrgGPmP+2/zTf7cssXPiMmAQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@babel/runtime": "^7.25.0",
+        "@types/d3-color": "^3.1.3",
+        "@types/d3-delaunay": "^6.0.4",
+        "@types/d3-interpolate": "^3.0.4",
+        "@types/d3-scale": "^4.0.8",
+        "@types/d3-shape": "^3.1.6",
+        "@types/d3-time": "^3.0.3",
+        "d3-color": "^3.1.0",
+        "d3-delaunay": "^6.0.4",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.2.0",
+        "d3-time": "^3.1.0",
+        "delaunator": "^5.0.1",
+        "robust-predicates": "^3.0.2"
+      }
+    },
     "node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {
       "version": "5.1.1-v1",
       "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/eslint-scope-5-internals/-/eslint-scope-5-internals-5.1.1-v1.tgz",
@@ -3687,6 +3745,78 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
+      }
+    },
+    "node_modules/@react-spring/animated": {
+      "version": "9.7.4",
+      "resolved": "https://registry.npmjs.org/@react-spring/animated/-/animated-9.7.4.tgz",
+      "integrity": "sha512-7As+8Pty2QlemJ9O5ecsuPKjmO0NKvmVkRR1n6mEotFgWar8FKuQt2xgxz3RTgxcccghpx1YdS1FCdElQNexmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-spring/shared": "~9.7.4",
+        "@react-spring/types": "~9.7.4"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@react-spring/core": {
+      "version": "9.7.4",
+      "resolved": "https://registry.npmjs.org/@react-spring/core/-/core-9.7.4.tgz",
+      "integrity": "sha512-GzjA44niEJBFUe9jN3zubRDDDP2E4tBlhNlSIkTChiNf9p4ZQlgXBg50qbXfSXHQPHak/ExYxwhipKVsQ/sUTw==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-spring/animated": "~9.7.4",
+        "@react-spring/shared": "~9.7.4",
+        "@react-spring/types": "~9.7.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-spring/donate"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@react-spring/rafz": {
+      "version": "9.7.4",
+      "resolved": "https://registry.npmjs.org/@react-spring/rafz/-/rafz-9.7.4.tgz",
+      "integrity": "sha512-mqDI6rW0Ca8IdryOMiXRhMtVGiEGLIO89vIOyFQXRIwwIMX30HLya24g9z4olDvFyeDW3+kibiKwtZnA4xhldA==",
+      "license": "MIT"
+    },
+    "node_modules/@react-spring/shared": {
+      "version": "9.7.4",
+      "resolved": "https://registry.npmjs.org/@react-spring/shared/-/shared-9.7.4.tgz",
+      "integrity": "sha512-bEPI7cQp94dOtCFSEYpxvLxj0+xQfB5r9Ru1h8OMycsIq7zFZon1G0sHrBLaLQIWeMCllc4tVDYRTLIRv70C8w==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-spring/rafz": "~9.7.4",
+        "@react-spring/types": "~9.7.4"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@react-spring/types": {
+      "version": "9.7.4",
+      "resolved": "https://registry.npmjs.org/@react-spring/types/-/types-9.7.4.tgz",
+      "integrity": "sha512-iQVztO09ZVfsletMiY+DpT/JRiBntdsdJ4uqk3UJFhrhS8mIC9ZOZbmfGSRs/kdbNPQkVyzucceDicQ/3Mlj9g==",
+      "license": "MIT"
+    },
+    "node_modules/@react-spring/web": {
+      "version": "9.7.4",
+      "resolved": "https://registry.npmjs.org/@react-spring/web/-/web-9.7.4.tgz",
+      "integrity": "sha512-UMvCZp7I5HCVIleSa4BwbNxynqvj+mJjG2m20VO2yPoi2pnCYANy58flvz9v/YcXTAvsmL655FV3pm5fbr6akA==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-spring/animated": "~9.7.4",
+        "@react-spring/core": "~9.7.4",
+        "@react-spring/shared": "~9.7.4",
+        "@react-spring/types": "~9.7.4"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/@reduxjs/toolkit": {
@@ -4432,6 +4562,57 @@
         "@types/express-serve-static-core": "*",
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-P2dlU/q51fkOc/Gfl3Ul9kicV7l+ra934qBFXCFhrZMOL6du1TM0pm1ThYvENukyOn5h9v+yMJ9Fn5JK4QozrQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.8.tgz",
+      "integrity": "sha512-gkK1VVTr5iNiYJ7vWDI+yUFFlszhNMtVeneJ6lUTKPjprsvLLI9/tgEGiXJOnlINJA8FyA88gfnQsHbybVZrYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.6.tgz",
+      "integrity": "sha512-5KKk5aKGu2I+O6SONMYSNflgiP0WfZIQvVUMan50wHsLG1G94JlxEVnCpQARfTtzytuY0p/9PXXZb3I7giofIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.3.tgz",
+      "integrity": "sha512-2p6olUZ4w3s+07q3Tm2dbiMZy5pCDfYwtLXXHUnVzXgQlZ/OyPtUz6OL382BkOuGlLXqfT+wqv8Fw2v8/0geBw==",
+      "license": "MIT"
     },
     "node_modules/@types/eslint": {
       "version": "8.56.11",
@@ -6971,6 +7152,121 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
+      "license": "ISC",
+      "dependencies": {
+        "delaunator": "5"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
+      "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
@@ -7165,6 +7461,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/delaunator": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.0.1.tgz",
+      "integrity": "sha512-8nvh+XBe96aCESrGOqMp/84b13H9cdKbG5P2ejQCh4d4sK9RL4371qou9drQjMhvnPmhWl5hnmqbEE0fXr9Xnw==",
+      "license": "ISC",
+      "dependencies": {
+        "robust-predicates": "^3.0.2"
       }
     },
     "node_modules/delayed-stream": {
@@ -9810,6 +10115,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/ipaddr.js": {
@@ -15801,6 +16115,12 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/robust-predicates": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.2.tgz",
+      "integrity": "sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg==",
+      "license": "Unlicense"
     },
     "node_modules/rollup": {
       "version": "2.79.1",

--- a/frontend/soltravel/package.json
+++ b/frontend/soltravel/package.json
@@ -6,6 +6,7 @@
     "@emotion/react": "^11.13.0",
     "@emotion/styled": "^11.13.0",
     "@mui/material": "^5.16.7",
+    "@mui/x-charts": "^7.14.0",
     "@reduxjs/toolkit": "^2.2.7",
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^13.4.0",

--- a/frontend/soltravel/src/App.tsx
+++ b/frontend/soltravel/src/App.tsx
@@ -19,11 +19,12 @@ import Exchange from "./pages/exchange/Exchange";
 import SelectAccount from "./pages/exchange/SelectAccount";
 import SettleStart from "./pages/settle/SettleStart";
 import Settlement from "./pages/settle/Settlement";
-import SettleExchange from "./pages/settle/SettleExchange";
 import Detail from "./pages/viewaccount/Detail";
 import GroupAccountPage from "./pages/viewaccount/ViewAccount";
 import AccountCreateComplete from "./pages/account/AccountCreateComplete";
-import MeetingAccountCreate from "./pages/account/MeetingAccountCreate";
+import GeneralMeetingAccountCreate from "./pages/account/GeneralMeetingAccountCreate";
+import MeetingAccountCreatePrepare from "./pages/account/MeetingAccountCreatePrepare";
+import ForeignMeetingAccountCreate from "./pages/account/ForeignMeetingAccountCreate";
 
 function App() {
   return (
@@ -63,17 +64,18 @@ function App() {
           <Route path="/mypage" element={<MyPage />} />
           <Route path="/userupdate" element={<UserUpdate />} />
           <Route path="/accountcreate" element={<AccountCreate />}></Route>
-          <Route path="/meetingaccountcreate" element={<MeetingAccountCreate />}></Route>
+          <Route path="/meetingaccountcreateprepare" element={<MeetingAccountCreatePrepare />}></Route>
+          <Route path="/generalmeetingaccountcreate" element={<GeneralMeetingAccountCreate />}></Route>
+          <Route path="/foreignmeetingaccountcreate" element={<ForeignMeetingAccountCreate />}></Route>
           <Route path="/accountcreatecomplete" element={<AccountCreateComplete />}></Route>
           <Route path="/myaccount" element={<MyAccount />}></Route>
           <Route path="/generalaccount" element={<GeneralAccount />}></Route>
           <Route path="/foreignaccount" element={<ForeignAccount />}></Route>
           <Route path="/account" element={<ViewAccount />}></Route>
           <Route path="/exchange" element={<Exchange />}></Route>
-          <Route path="/selectaccount" element={<SelectAccount />}></Route>
+          <Route path="/selectaccount/:userId" element={<SelectAccount />}></Route>
           <Route path="/settlestart" element={<SettleStart />}></Route>
           <Route path="/settlement" element={<Settlement />}></Route>
-          <Route path="/settleexchange" element={<SettleExchange />}></Route>
           <Route path="/detail" element={<Detail />}></Route>
           <Route path="/test" element={<Detail />}></Route>
         </Routes>

--- a/frontend/soltravel/src/api/account.ts
+++ b/frontend/soltravel/src/api/account.ts
@@ -5,22 +5,13 @@ import { AccountInfo } from "../types/account";
 export const accountApi = {
     // 일반 계좌 정보 가져오기
     fetchAccountInfo: async (userId: string): Promise<AccountInfo[]> => {
-      try {
-        const response = await api.get(`/account/general/${userId}/all`);
-        return response.data;
-      } catch (error) {
-        throw new Error('Failed to fetch account info');
-      }
+      const response = await api.get(`/account/general/${userId}/all`)
+      return response.data
     },
   
     // 외화 계좌 정보 가져오기
     fetchForeignAccountInfo: async (userId: string): Promise<AccountInfo[]> => {
-      try {
-        const response = await api.get(`/account/foreign/${userId}/all`);
-        return response.data;
-      } catch (error) {
-        throw new Error('Failed to fetch foreign account info');
-      }
-    },
-}
-
+      const response = await api.get(`/account/foreign/${userId}/all`)
+      return response.data
+    }
+};

--- a/frontend/soltravel/src/api/exchange.ts
+++ b/frontend/soltravel/src/api/exchange.ts
@@ -1,0 +1,22 @@
+import api from "../lib/axios";
+import { ExchangeRateInfo, ExchangeRequest, ExchangeResponse, ExchangeRateHistoryRequest, ExchangeRateHistoryResponse } from "../types/exchange";
+
+export const exchangeApi = {
+  getExchangeRates: async (): Promise<ExchangeRateInfo[]> => {
+    const response = await api.get('/exchange');
+    console.log(response.data)
+    return response.data
+  },
+
+  requestExchange: async (data: ExchangeRequest): Promise<ExchangeResponse> => {
+    const response = await api.post<ExchangeResponse>('/exchange', data)
+    return response.data
+  },
+
+  getExchangeRateHistory: async (data: ExchangeRateHistoryRequest): Promise<ExchangeRateHistoryResponse> => {
+    const response = await api.post<ExchangeRateHistoryResponse>('/exchange/latest', data);
+    console.log(response.data)
+    return response.data
+  }
+};
+

--- a/frontend/soltravel/src/api/user.ts
+++ b/frontend/soltravel/src/api/user.ts
@@ -1,0 +1,17 @@
+import api from "../lib/axios";
+
+export const userApi = {
+  // 회원가입
+  fetchSignUp: async (formData: FormData) => {
+    const response = await api.post(`/user/join`, formData, {
+      headers: {
+        "Content-Type": "multipart/form-data",
+      },
+    });
+    return response.data;
+  },
+  fetchNotificationSubscribe: async () => {
+    const response = await api.get("/notification/subscribe");
+    return response.data;
+  },
+};

--- a/frontend/soltravel/src/components/account/AccountDetail.tsx
+++ b/frontend/soltravel/src/components/account/AccountDetail.tsx
@@ -50,7 +50,7 @@ const AccountDetail = () => {
               }}
               className="w-full h-9 p-2 rounded-md bg-[#0046FF] text-white text-sm font-bold"
             >
-              재환전
+              환전
             </button>
           </div>
         </div>
@@ -88,7 +88,7 @@ const AccountDetail = () => {
           }}
           className="w-full h-9 p-2 rounded-md bg-[#0046FF] text-white text-sm font-bold"
         >
-          환전
+          재환전
         </button>
       </div>
     </div>

--- a/frontend/soltravel/src/components/account/inputField/ExchangeRateInput.tsx
+++ b/frontend/soltravel/src/components/account/inputField/ExchangeRateInput.tsx
@@ -1,0 +1,72 @@
+import { TextField } from "@mui/material";
+import React, { useEffect, useState } from "react";
+import { currencyTypeList } from "../../../types/exchange";
+import { AiTwotoneExclamationCircle } from "react-icons/ai";
+
+interface ExchangeRateInputProps {
+  currencyType: string;
+  exchangeRate: number;
+  onChange: (exchangeRate: number) => void;
+}
+
+const ExchangeRateInput: React.FC<ExchangeRateInputProps> = ({ currencyType, exchangeRate, onChange }) => {
+  const [currentExchangeRate, setCurrentExchangeRate] = useState("1592.88");
+  const [currencyTypeSymbol, setCurrencyTypeSymbol] = useState("");
+
+  useEffect(() => {
+    let temp = currencyTypeList.find((item) => item.value === currencyType);
+    if (temp) {
+      setCurrencyTypeSymbol(temp.text.charAt(temp.text.length - 2));
+    }
+  }, [currencyType]);
+
+  return (
+    <div className="grid gap-1">
+      <div className="flex justify-end items-center space-x-1">
+        <AiTwotoneExclamationCircle />
+        <p>현재 {currencyType}의 환율</p>
+        <p>:</p>
+        <p className="text-[#0471E9] font-semibold">{currentExchangeRate}</p>
+        <p className="text-[#565656] font-semibold">{currencyTypeSymbol}</p>
+      </div>
+
+      <TextField
+        sx={{
+          width: "100%",
+          "& .MuiInputBase-root": {
+            backgroundColor: "white",
+          },
+          "& .MuiInputBase-input": {
+            backgroundColor: "white",
+            fontSize: "20px",
+            fontWeight: "bold",
+            border: "1px solid #9E9E9E",
+            borderRadius: "10px",
+            textAlign: "right",
+          },
+          "& .MuiInputLabel-root": {
+            color: "#9E9E9E",
+            fontSize: "20px",
+          },
+          "& .MuiInputLabel-shrink": {
+            fontSize: "16px",
+          },
+          "& .MuiFilledInput-underline:before, & .MuiFilledInput-underline:after": {
+            display: "none",
+          },
+        }}
+        id="filled-basic"
+        label="희망 환율"
+        variant="filled"
+        value={exchangeRate}
+        onChange={(e) => {
+          onChange(Number(e.target.value));
+        }}
+        inputProps={{ inputMode: "decimal" }}
+        autoComplete="off"
+      />
+    </div>
+  );
+};
+
+export default ExchangeRateInput;

--- a/frontend/soltravel/src/components/account/inputField/MemberSelect.tsx
+++ b/frontend/soltravel/src/components/account/inputField/MemberSelect.tsx
@@ -1,0 +1,83 @@
+import React, { useState } from "react";
+import { styled } from "@mui/material/styles";
+import Chip from "@mui/material/Chip";
+import Paper from "@mui/material/Paper";
+import { FormControl, OutlinedInput } from "@mui/material";
+
+interface MemberSelectProps {
+  memberList: Array<string>;
+  onChange: (addMember: string) => void;
+  onDelete: (deleteMember: number) => void;
+}
+
+const ListItem = styled("li")(({ theme }) => ({
+  margin: theme.spacing(0.5),
+}));
+
+const MemberSelect: React.FC<MemberSelectProps> = ({ memberList, onChange, onDelete }) => {
+  const [addMember, setAddMember] = useState("");
+  const [hover, setHover] = useState(false);
+
+  const handleAddMember = () => {
+    onChange(addMember);
+    setAddMember("");
+  };
+
+  const handleDelete = (indexToDelete: number) => () => {
+    onDelete(indexToDelete);
+  };
+
+  return (
+    <div className="grid gap-3">
+      <div className="grid grid-cols-[3fr_1fr] gap-3">
+        <form noValidate autoComplete="off">
+          <FormControl sx={{ width: "100%" }}>
+            <OutlinedInput
+              sx={{
+                "&.Mui-focused .MuiOutlinedInput-notchedOutline": {
+                  border: "1px solid #9E9E9E",
+                },
+              }}
+              value={addMember}
+              placeholder={hover ? "" : "초대할 아이디 입력"}
+              onChange={(e) => setAddMember(e.target.value)}
+              onMouseEnter={() => setHover(true)}
+              onMouseLeave={() => setHover(false)}
+            />
+          </FormControl>
+        </form>
+
+        <button
+          className={`border border-[#cecece] rounded-md ${addMember === "" ? "opacity-50" : ""}`}
+          disabled={addMember === ""}
+          onClick={() => handleAddMember()}>
+          초대
+        </button>
+      </div>
+
+      <div className="p-3 border rounded-md">
+        <Paper
+          sx={{
+            display: "flex",
+            justifyContent: "left",
+            flexWrap: "wrap",
+            listStyle: "none",
+            m: 0,
+            boxShadow: "none",
+          }}
+          component="ul">
+          {memberList.map((member, index) => {
+            return (
+              <ListItem key={index}>
+                <Chip label={member} onDelete={member === "허동원" ? undefined : handleDelete(index)} />
+              </ListItem>
+            );
+          })}
+        </Paper>
+        <p className="text-sm text-[#565656] text-right">총 {memberList.length}명</p>
+      </div>
+    </div>
+  );
+};
+
+export default MemberSelect;

--- a/frontend/soltravel/src/components/account/inputField/ResidentNumberInput.tsx
+++ b/frontend/soltravel/src/components/account/inputField/ResidentNumberInput.tsx
@@ -1,13 +1,22 @@
-import React, { useRef } from "react";
+import React, { useEffect, useRef } from "react";
 import { TextField } from "@mui/material";
 
 interface ResidentNumberInputProps {
+  stepInfo: { currentStep: number; closeStep: number };
   residentNumber: string;
   onChange: (number: string) => void;
 }
 
-const ResidentNumberInput: React.FC<ResidentNumberInputProps> = ({ residentNumber, onChange }) => {
+const ResidentNumberInput: React.FC<ResidentNumberInputProps> = ({ stepInfo, residentNumber, onChange }) => {
   const residentNumberRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (stepInfo.currentStep === stepInfo.closeStep) {
+      if (residentNumberRef.current) {
+        residentNumberRef.current.blur();
+      }
+    }
+  }, [stepInfo]);
 
   return (
     <TextField

--- a/frontend/soltravel/src/components/account/inputField/TravelDateRangePicker.tsx
+++ b/frontend/soltravel/src/components/account/inputField/TravelDateRangePicker.tsx
@@ -1,0 +1,43 @@
+import React, { useEffect, useState } from "react";
+import { Dayjs } from "dayjs";
+import { DemoContainer } from "@mui/x-date-pickers/internals/demo";
+import { LocalizationProvider } from "@mui/x-date-pickers/LocalizationProvider";
+import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
+import { DatePicker } from "@mui/x-date-pickers/DatePicker";
+
+interface TravelDateRangeInputProps {
+  schedule: { startDate: Dayjs | null; endDate: Dayjs | null };
+  onStartChange: (startDate: Dayjs) => void;
+  onEndChange: (endDate: Dayjs) => void;
+}
+
+const TravelDateRangePicker: React.FC<TravelDateRangeInputProps> = ({ schedule, onStartChange, onEndChange }) => {
+  return (
+    <LocalizationProvider dateAdapter={AdapterDayjs}>
+      <DemoContainer components={["DatePicker", "DatePicker"]}>
+        <div className="flex space-x-2">
+          <DatePicker
+            label="출발일"
+            value={schedule.startDate && schedule.startDate}
+            onChange={(newValue) => {
+              if (newValue) {
+                onStartChange(newValue);
+              }
+            }}
+          />
+          <DatePicker
+            label="도착일"
+            value={schedule.endDate && schedule.endDate}
+            onChange={(newValue) => {
+              if (newValue) {
+                onEndChange(newValue);
+              }
+            }}
+          />
+        </div>
+      </DemoContainer>
+    </LocalizationProvider>
+  );
+};
+
+export default TravelDateRangePicker;

--- a/frontend/soltravel/src/components/account/inputField/TypeSelect.tsx
+++ b/frontend/soltravel/src/components/account/inputField/TypeSelect.tsx
@@ -1,0 +1,58 @@
+import { FormControl, InputLabel, MenuItem } from "@mui/material";
+import React from "react";
+import Select from "@mui/material/Select";
+
+interface TypeInputProps {
+  label: string;
+  menuList: Array<{ text: string; value: string }>;
+  selectedType: string;
+  onChange: (meetingType: string) => void;
+}
+
+const TypeSelect: React.FC<TypeInputProps> = ({ label, menuList, selectedType, onChange }) => {
+  return (
+    <FormControl
+      variant="filled"
+      sx={{
+        width: "100%",
+        "& .MuiInputBase-root": {
+          backgroundColor: "white",
+        },
+        "& .MuiInputBase-input": {
+          backgroundColor: "white",
+          fontSize: "20px",
+          fontWeight: "bold",
+          border: "1px solid #9E9E9E",
+          borderRadius: "10px",
+        },
+        "& .MuiInputLabel-root": {
+          fontSize: "20px",
+        },
+        "& .MuiInputLabel-shrink": {
+          fontSize: "16px",
+        },
+        "& .MuiFilledInput-underline:before, & .MuiFilledInput-underline:after": {
+          display: "none",
+        },
+        "& .MuiSelect-select:focus": {
+          backgroundColor: "white",
+          borderRadius: "10px",
+        },
+      }}>
+      <InputLabel id="demo-simple-select-filled-label">{label}</InputLabel>
+      <Select
+        labelId="demo-simple-select-filled-label"
+        id="demo-simple-select-filled"
+        value={selectedType}
+        onChange={(e) => onChange(e.target.value)}>
+        {menuList.map((menu, index) => (
+          <MenuItem value={menu.value} key={index}>
+            {menu.text}
+          </MenuItem>
+        ))}
+      </Select>
+    </FormControl>
+  );
+};
+
+export default TypeSelect;

--- a/frontend/soltravel/src/components/exchange/ExchangeRate.tsx
+++ b/frontend/soltravel/src/components/exchange/ExchangeRate.tsx
@@ -1,0 +1,92 @@
+import React, { useState, useEffect } from 'react';
+import { exchangeApi } from '../../api/exchange';
+import { ExchangeRateInfo as ExchangeRateInfoType } from '../../types/exchange';
+import { currencyNames } from '../../types/exchange';
+
+interface ExchangeRateInfoProps {
+  onExchangeClick?: () => void;
+  onCurrencyChange: (currency: string) => void;
+}
+
+const ExchangeRateInfo = ({ onExchangeClick, onCurrencyChange }: ExchangeRateInfoProps): React.ReactElement => {
+  const [currencies, setCurrencies] = useState<ExchangeRateInfoType[]>([]);
+  const [selectedCurrency, setSelectedCurrency] = useState<ExchangeRateInfoType | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetchExchangeRates();
+  }, []);
+
+  const fetchExchangeRates = async () => {
+    setError(null);
+    try {
+      const data = await exchangeApi.getExchangeRates();
+      setCurrencies(data);
+      if (data.length > 0) {
+        setSelectedCurrency(data[0]);
+      }
+    } catch (error) {
+      setError('환율 정보를 가져오는 데 실패했습니다. 다시 시도해 주세요.');
+    }
+  };
+
+  const getCurrencyName = (code: string) => {
+    return currencyNames[code] || code;
+  };
+
+  const handleCurrencyChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const newCurrency = e.target.value;
+    setSelectedCurrency(currencies.find(c => c.currencyCode === newCurrency) || null);
+    onCurrencyChange(newCurrency);
+  };
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <h2 className="text-sm font-semibold mb-1">통화</h2>
+        <select
+          className="w-full border rounded p-2"
+          onChange={handleCurrencyChange}
+          value={selectedCurrency?.currencyCode || ''}
+        >
+          {currencies.map((currency) => (
+            <option key={currency.currencyCode} value={currency.currencyCode}>
+              {getCurrencyName(currency.currencyCode)} ({currency.currencyCode})
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {selectedCurrency && (
+        <div className="border rounded p-2">
+          <div className="text-sm text-gray-500">
+            현재 매매기준율
+          </div>
+          <div className="flex justify-between items-center">
+            <span>{`1 ${getCurrencyName(selectedCurrency.currencyCode)} (${selectedCurrency.currencyCode})`}</span>
+            <span className="text-[#0046FF] font-bold">{selectedCurrency.exchangeRate.toFixed(2)}원</span>
+          </div>
+          <div className="text-sm text-gray-500 mt-1">
+            최소 환전액: {selectedCurrency.exchangeMin.toLocaleString()}원
+          </div>
+          <div className="text-xs text-gray-400 mt-1">
+            갱신 시간: {new Date(selectedCurrency.created).toLocaleString()}
+          </div>
+        </div>
+      )}
+
+      {error && <div className="text-red-500">{error}</div>}
+
+      {onExchangeClick && (
+        <button 
+          className="w-full py-2 bg-[#0046FF] text-white font-bold rounded"
+          onClick={onExchangeClick}
+        >
+          환전하기
+        </button>
+      )}
+    </div>
+  );
+};
+
+export default ExchangeRateInfo;

--- a/frontend/soltravel/src/components/exchange/ExchangeRateChart.tsx
+++ b/frontend/soltravel/src/components/exchange/ExchangeRateChart.tsx
@@ -1,0 +1,94 @@
+import React, { useState, useEffect } from 'react';
+import { LineChart } from '@mui/x-charts/LineChart';
+import { exchangeApi } from '../../api/exchange';
+import { currencyNames } from '../../types/exchange';
+import { ExchangeRateHistoryResponse } from '../../types/exchange';
+
+interface ExchangeRateChartProps {
+  currency: string;
+}
+
+const ExchangeRateChart: React.FC<ExchangeRateChartProps> = ({ currency }) => {
+  const [chartData, setChartData] = useState<ExchangeRateHistoryResponse[]>([]);
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetchExchangeRateHistory();
+  }, [currency]);
+
+  const fetchExchangeRateHistory = async () => {
+    setIsLoading(true);
+    setError(null);
+    const endDate = new Date().toISOString().split('T')[0];
+    const startDate = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString().split('T')[0];
+
+    try {
+      const data = await exchangeApi.getExchangeRateHistory({
+        currencyCode: currency || 'CAD',
+        startDate,
+        endDate,
+      });
+      if (!Array.isArray(data)) {
+        setChartData([data]);
+      } else {
+        setChartData(data);
+      }
+    } catch (error) {
+      console.error('Failed to fetch exchange rate history:', error);
+      setError('환율 정보를 불러오는데 실패했습니다.');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const renderChart = () => {
+    if (isLoading) {
+      return <div>데이터를 불러오는 중...</div>;
+    }
+
+    if (error) {
+      return <div className="text-red-500">{error}</div>;
+    }
+
+    if (!chartData || chartData.length === 0) {
+      return <div>표시할 데이터가 없습니다.</div>;
+    }
+
+    const formattedData = chartData.map((dataPoint) => ({
+      date: new Date(dataPoint.postAt).toLocaleDateString(),
+      rate: dataPoint.dealBasR, // 각 데이터 포인트의 환율
+    }));
+
+    return (
+      <LineChart
+        xAxis={[{ 
+          dataKey: 'date',
+          scaleType: 'band',
+          tickLabelStyle: { angle: 45, textAnchor: 'start', dominantBaseline: 'hanging' }
+        }]}
+        series={[
+          {
+            dataKey: 'rate',
+            area: true,
+            label: `${currencyNames[currency] || currency}`,
+          },
+        ]}
+        dataset={formattedData}
+        height={300}
+        margin={{ left: 50, right: 50, top: 20, bottom: 50 }}
+      />
+    );
+  };
+
+  return (
+    <div>
+      <h2 className="text-lg font-semibold mb-4">최근 30일 환율 변동</h2>
+      <div className="mt-4" style={{ height: '300px', width: '100%' }}>
+        {renderChart()}
+      </div>
+    </div>
+  );
+};
+
+export default ExchangeRateChart;

--- a/frontend/soltravel/src/components/user/UserForm.tsx
+++ b/frontend/soltravel/src/components/user/UserForm.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import Box from "@mui/material/Box";
 import TextField from "@mui/material/TextField";
 import Button from "@mui/material/Button";
@@ -14,18 +14,13 @@ interface InputState {
   verificationCode?: string;
 }
 
-const UserForm = () => {
-  const [inputs, setInputs] = useState<InputState>({
-    email: "",
-    password: "",
-    confirmPassword: "",
-    name: "",
-    birthday: "",
-    phone: "",
-    address: "",
-    verificationCode: "",
-  });
+interface Props {
+  inputs: InputState;
+  setInputs: (value: React.SetStateAction<InputState>) => void;
+  setIsFormValid: (value: boolean) => void;
+}
 
+const UserForm = ({ inputs, setInputs, setIsFormValid }: Props) => {
   const [errors, setErrors] = useState({
     email: false,
     password: false,
@@ -34,10 +29,9 @@ const UserForm = () => {
     birthday: false,
     phone: false,
     address: false,
-    verificationCode: false,
+    // verificationCode: false,
   });
 
-  const [showVerificationInput, setShowVerificationInput] = useState(false);
 
   const handleValidation = (id: string, value: string) => {
     let error = false;
@@ -101,38 +95,18 @@ const UserForm = () => {
     setErrors((prev) => ({ ...prev, [id]: error }));
   };
 
-  const validateInputs = () => {
-    const newErrors = {
-      email: handleValidation("email", inputs.email),
-      password: handleValidation("password", inputs.password),
-      confirmPassword: handleValidation("confirmPassword", inputs.confirmPassword),
-      name: handleValidation("name", inputs.name),
-      birthday: handleValidation("birthday", inputs.birthday),
-      phone: handleValidation("phone", inputs.phone),
-      address: handleValidation("address", inputs.address),
-      verificationCode: handleValidation("verificationCode", inputs.verificationCode || ""),
-    };
-    setErrors(newErrors);
-    return !Object.values(newErrors).some((error) => error);
-  };
+  useEffect(() => {
+    // 모든 필드가 유효한지 확인
+    const allFieldsValid = Object.values(errors).every((error) => !error);
+    const allFieldsFilled = Object.values(inputs).every((value) => value !== "");
 
-  const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault();
-    if (validateInputs()) {
-      // 유효성 검사 통과 시 처리 로직
-      console.log("Form submitted:", inputs);
-      // navigate("/next-page"); // 예: 회원가입 완료 페이지로 이동
-    }
-  };
+    setIsFormValid(allFieldsValid && allFieldsFilled);
+  }, [errors, inputs]);
+
 
   return (
     <>
-      <Box
-        className="w-full flex flex-col justify-center items-center space-y-5"
-        component="form"
-        noValidate
-        autoComplete="off"
-        onSubmit={handleSubmit}>
+      <Box className="w-full flex flex-col justify-center items-center space-y-5" component="form" noValidate autoComplete="off">
         <TextField
           required
           className="w-full h-14"
@@ -289,7 +263,8 @@ const UserForm = () => {
               // "&:hover": {
               //   backgroundColor: "#0036D4", // hover 상태에서의 배경색
               // },
-            }}>
+            }}
+          >
             <p className="text-xs font-semibold">인증번호</p>
             <p className="text-xs font-semibold">발송</p>
           </Button>

--- a/frontend/soltravel/src/components/viewaccount/AccountList.tsx
+++ b/frontend/soltravel/src/components/viewaccount/AccountList.tsx
@@ -6,7 +6,7 @@ type AccountDetailsProps = {
   onSelectAccount: (account: AccountInfo) => void;
 };
 
-const AccountDetails = ({ accounts, onSelectAccount }: AccountDetailsProps): React.ReactElement => {
+const AccountList = ({ accounts, onSelectAccount }: AccountDetailsProps): React.ReactElement => {
   return (
     <div>
       {accounts.map((account) => (
@@ -32,4 +32,4 @@ const AccountDetails = ({ accounts, onSelectAccount }: AccountDetailsProps): Rea
   );
 };
 
-export default AccountDetails;
+export default AccountList;

--- a/frontend/soltravel/src/components/viewaccount/GroupAccount.tsx
+++ b/frontend/soltravel/src/components/viewaccount/GroupAccount.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { accountApi } from '../../api/account';
 import { AccountInfo } from '../../types/account';
-import AccountDetails from './AccountList';
+import AccountList from './AccountList';
 
 const GroupAccount = (): React.ReactElement => {
   const [generalAccounts, setGeneralAccounts] = useState<AccountInfo[]>([]);
@@ -18,12 +18,13 @@ const GroupAccount = (): React.ReactElement => {
       if (userId) {
         try {
           setIsLoading(true);
-          const [generalAccountsData, foreignAccountsData] = await Promise.all([
+          const [generalAccount, foreignAccount] = await Promise.all([
             accountApi.fetchAccountInfo(userId),
             accountApi.fetchForeignAccountInfo(userId)
           ]);
-          setGeneralAccounts(generalAccountsData);
-          setForeignAccounts(foreignAccountsData);
+          // console.log(generalAccount, foreignAccount)
+          setGeneralAccounts(generalAccount);
+          setForeignAccounts(foreignAccount);
         } catch (error) {
           setError('계좌 정보를 불러오는 데 실패했습니다.');
           console.error('Error fetching account data:', error);
@@ -50,8 +51,9 @@ const GroupAccount = (): React.ReactElement => {
       
       {generalAccounts.length > 0 && (
         <>
-          <h2 className="text-xl font-semibold mb-2">일반 모임통장</h2>
-          <AccountDetails 
+          <h2 className="text-xl font-semibold mb-2">개인계좌 & 일반모임통장</h2>
+          <AccountList 
+            key="general"
             accounts={generalAccounts} 
             onSelectAccount={handleAccountSelect}
           />
@@ -60,8 +62,9 @@ const GroupAccount = (): React.ReactElement => {
       
       {foreignAccounts.length > 0 && (
         <>
-          <h2 className="text-xl font-semibold mb-2 mt-4">외화 모임통장</h2>
-          <AccountDetails 
+          <h2 className="text-xl font-semibold mb-2 mt-4">외화모임통장</h2>
+          <AccountList
+            key="foreign"
             accounts={foreignAccounts} 
             onSelectAccount={handleAccountSelect}
           />

--- a/frontend/soltravel/src/lib/axios.ts
+++ b/frontend/soltravel/src/lib/axios.ts
@@ -19,7 +19,6 @@ api.interceptors.request.use(
 
     // 로그인 기능이 아직 없으므로 임시로 accessToken 지정 후 사용
     const token = process.env.REACT_APP_ACCESS_TOKEN;
-    console.log(token)
     if (token) {
       config.headers.Authorization = `Bearer ${token}`;
     }

--- a/frontend/soltravel/src/pages/MainPage.tsx
+++ b/frontend/soltravel/src/pages/MainPage.tsx
@@ -91,7 +91,7 @@ const MainPage = () => {
           <button
             className="h-10 rounded-md bg-[#0046FF] font-bold text-white text-sm"
             onClick={() => {
-              navigate("/accountcreate");
+              navigate("/meetingaccountcreateprepare");
             }}>
             신청하기
           </button>

--- a/frontend/soltravel/src/pages/account/AccountCreate.tsx
+++ b/frontend/soltravel/src/pages/account/AccountCreate.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, useRef } from "react";
 import { RiHome5Line } from "react-icons/ri";
 import { useSelector, useDispatch } from "react-redux";
 import { setIsKeyboard, setAccountPassword } from "../../redux/accountSlice";
@@ -20,11 +20,21 @@ const AccountCreate = () => {
   const [residentNumber, setResidentNumber] = useState("");
   const [maskedPassword, setMaskedPassword] = useState("");
 
+  const residentNumberRef = useRef<HTMLInputElement>(null);
+
   useEffect(() => {
     if (accountPassword !== undefined) {
       setMaskedPassword("●".repeat(accountPassword.length));
     }
   }, [accountPassword]);
+
+  useEffect(() => {
+    if (step === 2) {
+      if (residentNumberRef.current) {
+        residentNumberRef.current.blur();
+      }
+    }
+  }, [step]);
 
   const handleNameChange = (name: string) => {
     setName(name);
@@ -84,7 +94,11 @@ const AccountCreate = () => {
                 step > 0 ? "translate-y-[3px]" : "translate-y-0"
               }`}>
               {step > 0 && (
-                <ResidentNumberInput residentNumber={residentNumber} onChange={handleResidentNumberChange} />
+                <ResidentNumberInput
+                  stepInfo={{ currentStep: step, closeStep: 2 }}
+                  residentNumber={residentNumber}
+                  onChange={handleResidentNumberChange}
+                />
               )}
             </div>
 

--- a/frontend/soltravel/src/pages/account/AccountCreateComplete.tsx
+++ b/frontend/soltravel/src/pages/account/AccountCreateComplete.tsx
@@ -23,7 +23,7 @@ const AccountCreateComplete = () => {
       <div className="w-full font-semibold row-start-3 flex flex-col justify-end space-y-3">
         <button
           className="w-full py-3 text-white bg-[#0471E9] rounded-lg"
-          onClick={() => navigate("/meetingaccountcreate")}>
+          onClick={() => navigate("/generalmeetingaccountcreate")}>
           모임통장 신청하기
         </button>
         <button className="w-full py-3 text-[#565656] border-2 rounded-lg" onClick={() => navigate("/")}>

--- a/frontend/soltravel/src/pages/account/ForeignMeetingAccountCreate.tsx
+++ b/frontend/soltravel/src/pages/account/ForeignMeetingAccountCreate.tsx
@@ -1,0 +1,161 @@
+import React, { useEffect, useState } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { RootState } from "../../redux/store";
+import { useNavigate } from "react-router";
+import { RiHome5Line } from "react-icons/ri";
+import TypeSelect from "../../components/account/inputField/TypeSelect";
+import { currencyTypeList } from "../../types/exchange";
+import ExchangeRateInput from "../../components/account/inputField/ExchangeRateInput";
+import TravleDateRangePicker from "../../components/account/inputField/TravelDateRangePicker";
+import { Dayjs } from "dayjs";
+
+const ForeignMeetingAccountCreate = () => {
+  // const {} = useSelector((state: RootState) => state.account);
+  const dispatch = useDispatch();
+  const navigate = useNavigate();
+
+  const [step, setStep] = useState(0);
+  const stepList = ["통화를", "희망 환율을", "여행 일정을"];
+  const [currencyType, setCurrencyType] = useState("");
+  const [exchangeRate, setExchangeRate] = useState(0);
+  const [travelSchedule, setTravelSchedule] = useState<{ startDate: Dayjs | null; endDate: Dayjs | null }>({
+    startDate: null,
+    endDate: null,
+  });
+
+  const handleCurrencyTypeChange = (currencyType: string) => {
+    setCurrencyType(currencyType);
+    if (currencyType !== "") {
+      setStep(1);
+      console.log(step);
+    }
+  };
+
+  const handleExchangeRateChange = (exchangeRate: number) => {
+    setExchangeRate(exchangeRate);
+    if (exchangeRate > 0) {
+      setStep(2);
+    }
+  };
+
+  const handleTravelStartDate = (startDate: Dayjs) => {
+    setTravelSchedule((prevSchedule) => ({
+      ...prevSchedule,
+      startDate,
+    }));
+  };
+
+  const handleTravelEndDate = (endDate: Dayjs) => {
+    setTravelSchedule((prevSchedule) => ({
+      ...prevSchedule,
+      endDate,
+    }));
+  };
+
+  const handleNext = () => {
+    // dispatch(
+    //   editGeneralMeetingAccountList({
+    //     generalMeetingAccountName: meetingName,
+    //     generalMeetingAccountIcon: meetingType,
+    //     generalMeetingAccountUserName: name,
+    //     generalMeetingAccountUserResidentNumber: residentNumber,
+    //     generalMeetingAccountPassword: accountPassword,
+    //     generalMeetingAccountMemberList: memberList,
+    //   })
+    // );
+
+    navigate("/accountcreatecomplete");
+  };
+
+  return (
+    <div className="h-full flex flex-col justify-between">
+      <div className="flex flex-col space-y-5">
+        <div className="p-5 grid grid-cols-[1fr_8fr_1fr]">
+          <div className="flex items-center">
+            <RiHome5Line className="text-2xl" />
+          </div>
+          <p className="text-xl text-center font-semibold">외화모임통장 가입정보</p>
+        </div>
+
+        <div className="p-5 grid gap-8">
+          <div className="grid gap-3">
+            <div className="flex space-x-2">
+              <p className="text-[#0471E9] font-semibold">02</p>
+              <p className="font-semibold">외화모임통장 계좌개설</p>
+            </div>
+
+            <div className="text-2xl font-semibold">
+              <p>{stepList[step]}</p>
+              <p>입력해주세요</p>
+            </div>
+          </div>
+
+          <div className="grid gap-3">
+            <div
+              className={`transition-transform duration-300 ease-in-out ${
+                step > 1 ? "translate-y-0" : "translate-y-[3px]"
+              }`}>
+              {step > 1 && (
+                <TravleDateRangePicker
+                  schedule={travelSchedule}
+                  onStartChange={handleTravelStartDate}
+                  onEndChange={handleTravelEndDate}
+                />
+              )}
+            </div>
+
+            <div
+              className={`transition-transform duration-300 ease-in-out ${
+                step > 0 ? "translate-y-0" : "translate-y-[3px]"
+              }`}>
+              {step > 0 && (
+                <ExchangeRateInput
+                  currencyType={currencyType}
+                  exchangeRate={exchangeRate}
+                  onChange={handleExchangeRateChange}
+                />
+              )}
+            </div>
+
+            <div
+              className={`transition-transform duration-300 ease-in-out ${
+                step === 0 ? "translate-y-0" : "translate-y-[3px]"
+              }`}>
+              <TypeSelect
+                label="통화"
+                menuList={currencyTypeList}
+                selectedType={currencyType}
+                onChange={handleCurrencyTypeChange}
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="px-5 py-10">
+        <button
+          className={`w-full py-3 text-white bg-[#0471E9] rounded-lg ${
+            step !== 2 ||
+            currencyType === "" ||
+            exchangeRate === 0 ||
+            travelSchedule.startDate === null ||
+            travelSchedule.endDate === null
+              ? "opacity-40"
+              : ""
+          }`}
+          onClick={() => handleNext()}
+          disabled={
+            step !== 2 ||
+            currencyType === "" ||
+            exchangeRate === 0 ||
+            travelSchedule.startDate === null ||
+            travelSchedule.endDate === null
+          }>
+          다음
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default ForeignMeetingAccountCreate;

--- a/frontend/soltravel/src/pages/account/GeneralMeetingAccountCreate.tsx
+++ b/frontend/soltravel/src/pages/account/GeneralMeetingAccountCreate.tsx
@@ -1,0 +1,253 @@
+import React, { useEffect, useState } from "react";
+import { RiHome5Line } from "react-icons/ri";
+import { useSelector, useDispatch } from "react-redux";
+import { setIsKeyboard, setAccountPassword, editGeneralMeetingAccountList } from "../../redux/accountSlice";
+import { RootState } from "../../redux/store";
+import SecurityKeyboard from "../../components/account/SecurityKeyboard";
+import { useNavigate } from "react-router";
+import NameInput from "../../components/account/inputField/NameInput";
+import ResidentNumberInput from "../../components/account/inputField/ResidentNumberInput";
+import PasswordInput from "../../components/account/inputField/PasswordInput";
+import MeetingTypeSelect from "../../components/account/inputField/TypeSelect";
+import MemberSelect from "../../components/account/inputField/MemberSelect";
+import { meetingAccountIconList } from "../../types/account";
+
+const MeetingAccountCreate = () => {
+  const { isKeyboard, accountPassword } = useSelector((state: RootState) => state.account);
+  const dispatch = useDispatch();
+  const navigate = useNavigate();
+
+  const [step, setStep] = useState(0);
+  const stepList = [
+    "모임 이름을",
+    "어떤 모임인지를",
+    "모임주 이름을",
+    "모임주 주민등록번호를",
+    "계좌 비밀번호를",
+    "모임원을",
+  ];
+
+  const [meetingName, setMeetingName] = useState("");
+  const [meetingType, setMeetingType] = useState("");
+  const [name, setName] = useState("");
+  const [residentNumber, setResidentNumber] = useState("");
+  const [maskedPassword, setMaskedPassword] = useState("");
+  const [memberList, setMemberList] = useState<Array<string>>(["허동원"]);
+
+  useEffect(() => {
+    // redux store의 기존 저장되어있던 정보 제거
+    dispatch(setAccountPassword(""));
+  }, []);
+
+  useEffect(() => {
+    if (accountPassword !== undefined) {
+      setMaskedPassword("●".repeat(accountPassword.length));
+    }
+  }, [accountPassword]);
+
+  const handleMeetingNameChange = (meetingname: string) => {
+    setMeetingName(meetingname);
+    if (meetingname.length >= 2) {
+      setStep(1);
+    }
+  };
+
+  const handleMeetingTypeChange = (meetingType: string) => {
+    setMeetingType(meetingType);
+    if (meetingType !== "") {
+      setStep(2);
+    }
+  };
+
+  const handleNameChange = (name: string) => {
+    setName(name);
+    if (name.length >= 3) {
+      setStep(3);
+    }
+  };
+
+  const handleResidentNumberChange = (number: string) => {
+    if (14 - number.length <= 6) {
+      let temp = number.substring(0, 8);
+      temp += "*".repeat(number.length - 8);
+      number = temp;
+    }
+
+    let masking = number.replace(/^(\d{0,6})(\d{0,7})$/g, "$1-$2").replace(/\-{1}$/g, "");
+    setResidentNumber(masking);
+
+    if (number.length === 14) {
+      // 하이픈 포함
+      setStep(4);
+      dispatch(setIsKeyboard(true));
+    }
+  };
+
+  const handlePasswordKeyboard = () => {
+    dispatch(setAccountPassword(""));
+    dispatch(setIsKeyboard(true));
+  };
+
+  const handleMemberListChange = (addMember: string) => {
+    setMemberList((prev) => [...prev, addMember]);
+  };
+
+  const handleMemberDelete = (deleteMember: number) => {
+    setMemberList((prev) => prev.filter((_, index) => index !== deleteMember));
+  };
+
+  const handleNext = () => {
+    dispatch(
+      editGeneralMeetingAccountList({
+        generalMeetingAccountName: meetingName,
+        generalMeetingAccountIcon: meetingType,
+        generalMeetingAccountUserName: name,
+        generalMeetingAccountUserResidentNumber: residentNumber,
+        generalMeetingAccountPassword: accountPassword,
+        generalMeetingAccountMemberList: memberList,
+      })
+    );
+
+    navigate("/foreignmeetingaccountcreate");
+  };
+
+  return (
+    <div className="h-full flex flex-col justify-between">
+      <div className="flex flex-col space-y-5">
+        <div className="p-5 grid grid-cols-[1fr_8fr_1fr]">
+          <div className="flex items-center">
+            <RiHome5Line className="text-2xl" />
+          </div>
+          <p className="text-xl text-center font-semibold">일반모임통장 가입정보</p>
+        </div>
+
+        <div className="p-5 grid gap-8">
+          <div className="grid gap-3">
+            <div className="flex space-x-2">
+              <p className="text-[#0471E9] font-semibold">01</p>
+              <p className="font-semibold">일반모임통장 계좌개설</p>
+            </div>
+
+            <div className="text-2xl font-semibold">
+              <p>{stepList[step]}</p>
+              <p>입력해주세요</p>
+            </div>
+          </div>
+
+          <div className="grid gap-3">
+            {step < 5 ? (
+              <>
+                <div
+                  className={`transition-transform duration-300 ease-in-out ${
+                    step > 3 ? "translate-y-[3px]" : "translate-y-0"
+                  }`}>
+                  {step > 3 && (
+                    <PasswordInput maskedPassword={maskedPassword} onKeyboardOpen={handlePasswordKeyboard} />
+                  )}
+                </div>
+
+                <div
+                  className={`transition-transform duration-300 ease-in-out ${
+                    step > 2 ? "translate-y-[3px]" : "translate-y-0"
+                  }`}>
+                  {step > 2 && (
+                    <ResidentNumberInput
+                      stepInfo={{ currentStep: step, closeStep: 4 }}
+                      residentNumber={residentNumber}
+                      onChange={handleResidentNumberChange}
+                    />
+                  )}
+                </div>
+
+                <div
+                  className={`transition-transform duration-300 ease-in-out ${
+                    step > 1 ? "translate-y-0" : "translate-y-[3px]"
+                  }`}>
+                  {step > 1 && <NameInput labelName="모임주" name={name} onChange={handleNameChange} />}
+                </div>
+
+                <div
+                  className={`transition-transform duration-300 ease-in-out ${
+                    step > 0 ? "translate-y-0" : "translate-y-[3px]"
+                  }`}>
+                  {step > 0 && (
+                    <MeetingTypeSelect
+                      label="모임종류"
+                      menuList={meetingAccountIconList}
+                      selectedType={meetingType}
+                      onChange={handleMeetingTypeChange}
+                    />
+                  )}
+                </div>
+
+                <div
+                  className={`transition-transform duration-300 ease-in-out ${
+                    step === 0 ? "translate-y-0" : "translate-y-[3px]"
+                  }`}>
+                  <NameInput labelName="모임명" name={meetingName} onChange={handleMeetingNameChange} />
+                </div>
+              </>
+            ) : (
+              <div
+                className={`transition-transform duration-300 ease-in-out ${
+                  step > 4 ? "translate-y-[3px]" : "translate-y-0"
+                }`}>
+                {step > 4 && (
+                  <MemberSelect
+                    memberList={memberList}
+                    onChange={handleMemberListChange}
+                    onDelete={handleMemberDelete}
+                  />
+                )}
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+
+      <div className="px-5 py-10">
+        {step < 5 ? (
+          <button
+            className={`w-full py-3 text-white bg-[#0471E9] rounded-lg ${
+              step !== 4 ||
+              meetingName.length < 1 ||
+              meetingType === "" ||
+              name.length < 2 ||
+              residentNumber.length !== 14 ||
+              maskedPassword.length !== 4
+                ? "opacity-40"
+                : ""
+            }`}
+            onClick={() => setStep(5)}
+            disabled={
+              step !== 4 ||
+              meetingName.length < 1 ||
+              meetingType === "" ||
+              name.length < 2 ||
+              residentNumber.length !== 14 ||
+              maskedPassword.length !== 4
+            }>
+            다음
+          </button>
+        ) : (
+          <button
+            className={`w-full py-3 text-white bg-[#0471E9] rounded-lg ${memberList.length < 2 ? "opacity-40" : ""}`}
+            onClick={() => handleNext()}
+            disabled={memberList.length < 2}>
+            다음
+          </button>
+        )}
+      </div>
+
+      {isKeyboard ? (
+        <div className="w-full fixed bottom-0">
+          <SecurityKeyboard />
+        </div>
+      ) : (
+        <></>
+      )}
+    </div>
+  );
+};
+
+export default MeetingAccountCreate;

--- a/frontend/soltravel/src/pages/account/MeetingAccountCreatePrepare.tsx
+++ b/frontend/soltravel/src/pages/account/MeetingAccountCreatePrepare.tsx
@@ -1,0 +1,85 @@
+import React from "react";
+import { RiHome5Line } from "react-icons/ri";
+import { FaMoneyCheck } from "react-icons/fa";
+import { FaMoneyCheckDollar } from "react-icons/fa6";
+import { AiTwotoneExclamationCircle } from "react-icons/ai";
+import { LuDot } from "react-icons/lu";
+import { useNavigate } from "react-router";
+
+const MeetingAccountCreateProcess = () => {
+  const navigate = useNavigate();
+  const noticeTextList = [
+    "개설 전, 개인 입출금통장이 존재해야합니다.",
+    "일반모임통장과 외화모임통장 모두를 개설해야합니다.",
+    "일반모임통장만 가입이 불가합니다.",
+    "외화모임통장만 가입이 불가합니다.",
+  ];
+
+  return (
+    <div className="h-full flex flex-col justify-between">
+      <div className="flex flex-col space-y-5">
+        <div className="p-5 grid grid-cols-[1fr_8fr_1fr]">
+          <div className="flex items-center">
+            <RiHome5Line className="text-2xl" />
+          </div>
+          <p className="text-xl text-center font-semibold">계좌 개설 안내</p>
+        </div>
+
+        <div className="p-5 grid gap-8">
+          <div className="text-2xl font-semibold">
+            <p>해외여행 올인원 모임통장</p>
+            <p>계좌개설에 대해 알려드립니다</p>
+          </div>
+
+          <div className="grid gap-5">
+            <div className="flex space-x-5">
+              <FaMoneyCheck className="mx-3 text-3xl text-[#565656]" />
+              <div className="flex space-x-2">
+                <p className="text-[#0471E9] font-semibold">01</p>
+                <div>
+                  <p className="font-semibold">일반모임통장 계좌개설</p>
+                  <p className="text-sm text-[#565656]">원화(KRW)로 관리되는 모임통장</p>
+                </div>
+              </div>
+            </div>
+
+            <div className="flex space-x-5">
+              <FaMoneyCheckDollar className="mx-3 text-3xl text-[#565656]" />
+              <div className="flex space-x-2">
+                <p className="text-[#0471E9] font-semibold">02</p>
+                <div>
+                  <p className="font-semibold">외화모임통장 계좌개설</p>
+                  <p className="text-sm text-[#565656]">원화는 통화로 관리되는 모임통장</p>
+                </div>
+              </div>
+            </div>
+
+            <div className="flex flex-col space-y-2">
+              <div className="flex items-center space-x-1">
+                <AiTwotoneExclamationCircle />
+                <p>알아두세요</p>
+              </div>
+
+              {noticeTextList.map((text, index) => (
+                <div className="flex" key={index}>
+                  <LuDot className="text-[#565656]" />
+                  <p className="text-xs text-[#565656]">{text}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="px-5 py-10">
+        <button
+          className={`w-full py-3 text-white bg-[#0471E9] rounded-lg`}
+          onClick={() => navigate("/generalmeetingaccountcreate")}>
+          가입하기
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default MeetingAccountCreateProcess;

--- a/frontend/soltravel/src/pages/exchange/Exchange.tsx
+++ b/frontend/soltravel/src/pages/exchange/Exchange.tsx
@@ -1,149 +1,205 @@
-import React, { useState, useEffect } from 'react';
-import { useParams } from 'react-router-dom';
+// import React, { useState, useEffect } from 'react';
+// import { useParams } from 'react-router-dom';
+// import { accountApi } from '../../api/account';
+// import { exchangeApi } from '../../api/exchange';
+// import { AccountInfo } from '../../types/account';
+// import { ExchangeRateInfo, ExchangeRequest } from '../../types/exchange';
 
-// 백에서 받아올 데이터를 interface로 type 설정 현재는 예시들
-interface Account {
-  id: string;
-  name: string;
-  accountNumber: string;
-  balance: number;
-  currency: string;
+// const Exchange: React.FC = () => {
+//   const { userId } = useParams<{ userId: string }>();
+//   const [accounts, setAccounts] = useState<AccountInfo[]>([]);
+//   const [selectedAccount, setSelectedAccount] = useState<AccountInfo | null>(null);
+//   const [exchangeRates, setExchangeRates] = useState<ExchangeRateInfo[]>([]);
+//   const [exchangeAmount, setExchangeAmount] = useState<string>('');
+//   const [selectedCurrency, setSelectedCurrency] = useState<string>('USD');
+//   const [expectedExchange, setExpectedExchange] = useState<string>('0');
+//   const [isLoading, setIsLoading] = useState<boolean>(false);
+
+//   useEffect(() => {
+//     const fetchData = async () => {
+//       try {
+//         const [fetchedAccounts, rates] = await Promise.all([
+//           accountApi.fetchAccountInfo(userId),
+//           exchangeApi.getExchangeRates()
+//         ]);
+//         setAccounts(fetchedAccounts);
+//         if (fetchedAccounts.length > 0) {
+//           setSelectedAccount(fetchedAccounts[0]);
+//         }
+//         setExchangeRates(rates);
+//         if (rates.length > 0) {
+//           setSelectedCurrency(rates[0].currencyCode);
+//         }
+//       } catch (error) {
+//         console.error('Error fetching data:', error);
+//         alert('데이터를 불러오는 데 실패했습니다.');
+//       }
+//     };
+
+//     fetchData();
+//   }, [userId]);
+
+//   useEffect(() => {
+//     if (exchangeAmount && exchangeRates.length > 0) {
+//       const rate = exchangeRates.find(r => r.currencyCode === selectedCurrency)?.exchangeRate;
+//       if (rate) {
+//         const expected = (parseFloat(exchangeAmount) * rate).toFixed(2);
+//         setExpectedExchange(expected);
+//       }
+//     } else {
+//       setExpectedExchange('0');
+//     }
+//   }, [exchangeAmount, selectedCurrency, exchangeRates]);
+
+//   const handleAccountChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+//     const account = accounts.find(acc => acc.accountNo === e.target.value);
+//     if (account) {
+//       setSelectedAccount(account);
+//     }
+//   };
+
+//   const handleExchangeAmountChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+//     setExchangeAmount(e.target.value);
+//   };
+
+//   const handleCurrencyChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+//     setSelectedCurrency(e.target.value);
+//   };
+
+//   const handleExchange = async () => {
+//     if (!selectedAccount) return;
+
+//     const numAmount = parseFloat(exchangeAmount);
+//     if (isNaN(numAmount) || numAmount <= 0) {
+//       alert('유효한 환전 금액을 입력해주세요.');
+//       return;
+//     }
+
+//     if (numAmount > selectedAccount.accountBalance) {
+//       alert('계좌 잔액이 부족합니다.');
+//       return;
+//     }
+
+//     const selectedRate = exchangeRates.find(r => r.currencyCode === selectedCurrency);
+//     if (!selectedRate) {
+//       alert('선택한 통화의 환율 정보를 찾을 수 없습니다.');
+//       return;
+//     }
+
+//     if (numAmount < selectedRate.exchangeMin) {
+//       alert(`최소 환전 금액은 ${selectedRate.exchangeMin} ${selectedAccount.currency}입니다.`);
+//       return;
+//     }
+
+//     const exchangeRequest: ExchangeRequest = {
+//       accountid: parseInt(selectedAccount.accountNo),
+//       accountNo: selectedAccount.accountNo,
+//       exchangeCurrency: selectedCurrency,
+//       exchangeAmount: numAmount,
+//       exchangeRate: selectedRate.exchangeRate
+//     };
+
+//     setIsLoading(true);
+//     try {
+//       const response = await exchangeApi.requestExchange(exchangeRequest);
+//       console.log('환전 완료:', response);
+//       alert(`환전이 완료되었습니다. 환전된 금액: ${response.exchangeCurrencyDto.amount} ${response.exchangeCurrencyDto.currency}`);
+//       // 환전 후 계좌 정보 업데이트
+//       setAccounts(accounts.map(acc => 
+//         acc.accountNo === selectedAccount.accountNo 
+//           ? { ...acc, accountBalance: response.accountInfoDto.balance }
+//           : acc
+//       ));
+//       setSelectedAccount({
+//         ...selectedAccount,
+//         accountBalance: response.accountInfoDto.balance,
+//       });
+//       setExchangeAmount('');
+//       setExpectedExchange('0');
+//     } catch (error) {
+//       console.error('환전 중 오류 발생:', error);
+//       alert('환전 중 오류가 발생했습니다. 다시 시도해주세요.');
+//     } finally {
+//       setIsLoading(false);
+//     }
+//   };
+
+//   if (accounts.length === 0 || !selectedAccount || exchangeRates.length === 0) {
+//     return <div>Loading...</div>;
+//   }
+
+//   return (
+//     <div className="p-4 max-w-md mx-auto bg-gray-100 min-h-screen">
+//       <h1 className="text-xl font-bold mb-4">환전하기</h1>
+//       <div className="bg-white rounded-lg p-4 shadow mb-4">
+//         <label htmlFor="account-select" className="block text-sm font-medium text-gray-700 mb-2">
+//           계좌 선택
+//         </label>
+//         <select
+//           id="account-select"
+//           className="w-full p-2 border rounded mb-2"
+//           value={selectedAccount.accountNo}
+//           onChange={handleAccountChange}
+//         >
+//           {accounts.map(account => (
+//             <option key={account.accountNo} value={account.accountNo}>
+//               {account.bankName} - {account.accountName} ({account.accountNo})
+//             </option>
+//           ))}
+//         </select>
+//       </div>
+//       <h2 className="font-bold mb-2">환전할 금액 입력</h2>
+//       <div className="bg-white rounded-lg p-4 shadow mb-4">
+//         <div className="flex items-center mb-2">
+//           <div className="w-8 h-8 bg-[#0046FF] rounded-full mr-2"></div>
+//           <div>
+//             <p className="font-semibold">{selectedAccount.accountName}</p>
+//             <p className="text-sm text-gray-500">{selectedAccount.bankName} {selectedAccount.accountNo}</p>
+//           </div>
+//         </div>
+//         <input
+//           type="number"
+//           className="w-full text-right text-2xl font-bold p-2 border rounded mb-2"
+//           value={exchangeAmount}
+//           onChange={handleExchangeAmountChange}
+//           placeholder="0"
+//         />
+//         <select
+//           className="w-full p-2 border rounded mb-2"
+//           value={selectedCurrency}
+//           onChange={handleCurrencyChange}
+//         >
+//           {exchangeRates.map(rate => (
+//             <option key={rate.currencyCode} value={rate.currencyCode}>{rate.currencyCode}</option>
+//           ))}
+//         </select>
+//         <p className="text-right text-sm text-gray-500">최대 {selectedAccount.accountBalance.toLocaleString()} {selectedAccount.currency} 가능</p>
+//         <p className="text-right text-sm text-gray-500">
+//           최소 {exchangeRates.find(r => r.currencyCode === selectedCurrency)?.exchangeMin.toLocaleString()} {selectedAccount.currency} 이상
+//         </p>
+//       </div>
+//       <div className="bg-white rounded-lg p-4 shadow mb-4">
+//         <p className="font-bold mb-2">예상 환전 금액</p>
+//         <p className="text-2xl font-bold">
+//           {parseFloat(expectedExchange) > 0 ? parseFloat(expectedExchange).toLocaleString() : '0'} {selectedCurrency}
+//         </p>
+//         <p className="text-sm text-gray-500">
+//           적용 환율: 1 {selectedAccount.currency} = {exchangeRates.find(r => r.currencyCode === selectedCurrency)?.exchangeRate.toFixed(2)} {selectedCurrency}
+//         </p>
+//       </div>
+//       <button
+//         className={`w-full bg-[#0046FF] text-white py-3 rounded-lg mt-4 ${isLoading ? 'opacity-50 cursor-not-allowed' : ''}`}
+//         onClick={handleExchange}
+//         disabled={isLoading}
+//       >
+//         {isLoading ? '환전 중...' : '환전하기'}
+//       </button>
+//     </div>
+//   );
+// };
+
+const Exchange = () => {
+  return <div>ㅎㅎ ㅈㅅ</div>
 }
-
-interface ExchangeRate {
-  currency: string;
-  date: string;
-  time: string;
-  round: string;
-  sendRate: number;
-  receiveRate: number;
-  buyRate: number;
-  sellRate: number;
-  baseRate: number;
-  usdConversionRate: number;
-}
-
-// 환전 요청
-const Exchange: React.FC = () => {
-  const { accountId } = useParams<{ accountId: string }>();
-  const [account, setAccount] = useState<Account | null>(null);
-  const [exchangeRate, setExchangeRate] = useState<ExchangeRate | null>(null);
-  const [exchangeAmount, setExchangeAmount] = useState<string>('');
-  const [expectedExchange, setExpectedExchange] = useState<string>('0');
-
-  useEffect(() => {
-    // 실제 구현에서는 API 호출로 대체해야 합니다.
-    const fetchAccountInfo = async () => {
-      // 예시 데이터
-      const mockAccount: Account = {
-        id: accountId || '',
-        name: '신한은행 올인원머니통장',
-        accountNumber: '신한 110-455-247307',
-        balance: 3000000,
-        currency: 'USD', // 예시로 USD 사용
-      };
-      setAccount(mockAccount);
-
-      // 예시 환율 데이터
-      const mockExchangeRate: ExchangeRate = {
-        currency: 'USD',
-        date: '2024.07.30',
-        time: '23:02:23',
-        round: '194',
-        sendRate: 1398.20,
-        receiveRate: 1371.80,
-        buyRate: 1409.23,
-        sellRate: 1360.77,
-        baseRate: 1383.00,
-        usdConversionRate: 1.0000,
-      };
-      setExchangeRate(mockExchangeRate);
-    };
-
-    fetchAccountInfo();
-  }, [accountId]);
-
-  // 환전할 돈을 입력한 후 취소 했을 때, NaN이 뜨지 않도록 하기
-  const handleExchangeAmountChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const amount = e.target.value;
-    setExchangeAmount(amount);
-    if (account && exchangeRate) {
-      const numAmount = parseFloat(amount);
-      if (!isNaN(numAmount) && numAmount > 0) {
-        const exchanged = (numAmount / exchangeRate.baseRate).toFixed(2);
-        setExpectedExchange(exchanged);
-      } else {
-        setExpectedExchange('0');
-      }
-    }
-  };
-
-  // 환전하기 버튼 (백으로 요청 보내는 로직 필요) : 여기서 계산을 하는건지, 백에서 계산을 한 값을 던져주는 건지?
-  const handleExchange = () => {
-    // 실제 환전 로직 구현 필요
-    console.log('환전 실행:', accountId, exchangeAmount, expectedExchange);
-  };
-
-  if (!account || !exchangeRate) {
-    return <div>Loading...</div>;
-  }
-
-  return (
-    <div className="p-4 max-w-md mx-auto bg-gray-100 min-h-screen">
-      <h1 className="text-xl font-bold mb-4">환전하기</h1>
-      <h2 className="font-bold mb-2">환전할 금액 입력</h2>
-      <div className="bg-white rounded-lg p-4 shadow mb-4">
-        <div className="flex items-center mb-2">
-          <div className="w-8 h-8 bg-[#0046FF] rounded-full mr-2"></div>
-          <div>
-            <p className="font-semibold">{account.name}</p>
-            <p className="text-sm text-gray-500">{account.accountNumber}</p>
-          </div>
-        </div>
-        <input
-          type="number"
-          className="w-full text-right text-2xl font-bold p-2 border rounded"
-          value={exchangeAmount}
-          onChange={handleExchangeAmountChange}
-          placeholder="0"
-        />
-        <p className="text-right text-sm text-gray-500">최대 {account.balance.toLocaleString()} 원 가능</p>
-      </div>
-      <div className="bg-white rounded-lg p-4 shadow mb-4">
-        <p className="font-bold mb-2">예상 환전 금액</p>
-        <p className="text-2xl font-bold">
-          {parseFloat(expectedExchange) > 0 ? parseFloat(expectedExchange).toLocaleString() : '0'} {account.currency}
-        </p>
-      </div>
-      <div className="bg-white rounded-lg p-4 shadow">
-        <h3 className="font-bold mb-2">{exchangeRate.currency}</h3>
-        <div className="grid grid-cols-2 gap-4 text-sm">
-          <p>기준일</p>
-          <p className="text-right">{exchangeRate.date}</p>
-          <p>고시시간/회차</p>
-          <p className="text-right">{exchangeRate.time} / {exchangeRate.round}회차</p>
-          <p>송금 보낼 때</p>
-          <p className="text-right">{exchangeRate.sendRate.toFixed(2)} 원</p>
-          <p>송금 받을 때</p>
-          <p className="text-right">{exchangeRate.receiveRate.toFixed(2)} 원</p>
-          <p>현찰 살 때</p>
-          <p className="text-right">{exchangeRate.buyRate.toFixed(2)} 원</p>
-          <p>현찰 팔 때</p>
-          <p className="text-right">{exchangeRate.sellRate.toFixed(2)} 원</p>
-          <p>매매기준율</p>
-          <p className="text-right">{exchangeRate.baseRate.toFixed(2)} 원</p>
-          <p>대미환산율</p>
-          <p className="text-right">{exchangeRate.usdConversionRate.toFixed(4)}</p>
-        </div>
-      </div>
-      <button
-        className="w-full bg-[#0046FF] text-white py-3 rounded-lg mt-4"
-        onClick={handleExchange}
-      >
-        환전하기
-      </button>
-    </div>
-  );
-};
 
 export default Exchange;

--- a/frontend/soltravel/src/pages/exchange/ExchangeRate.tsx
+++ b/frontend/soltravel/src/pages/exchange/ExchangeRate.tsx
@@ -1,212 +1,30 @@
-import React, { useState, useEffect } from 'react';
-import { Calendar, ChevronDown, Clock } from 'lucide-react';
-import { format } from 'date-fns';
-import { ko } from 'date-fns/locale';
-import { DayPicker } from 'react-day-picker';
-import 'react-day-picker/dist/style.css';
+import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import ExchangeRateInfo from '../../components/exchange/ExchangeRate';
+import ExchangeRateChart from '../../components/exchange/ExchangeRateChart';
 
-// 환율 관련 정보 백에서 받아올 준비 interface로 type 설정
-interface Currency {
-  code: string;
-  name: string;
-  amount: number;
-}
-
-interface TimeSlot {
-  id: number;
-  name: string;
-}
-
-// 선택 박스 설정 (이것도 백에서 주는거 확인 해야 함)
-const currencies: Currency[] = [
-  { code: 'JPY', name: '일본 엔', amount: 100 },
-  { code: 'USD', name: '미국 달러', amount: 1 },
-  { code: 'EUR', name: '유럽 유로', amount: 1 },
-  { code: 'CNY', name: '중국 위안', amount: 1 },
-  { code: 'GBP', name: '영국 파운드', amount: 1 },
-  { code: 'CHF', name: '스위스 프랑', amount: 1 },
-  { code: 'CAD', name: '캐나다 달러', amount: 1 },
-];
-
-const timeSlots: TimeSlot[] = [
-  { id: 1, name: '9:00 (1회차)' },
-  { id: 2, name: '11:00 (2회차)' },
-  { id: 3, name: '15:30 (3회차)' },
-];
-
-const ExchangeRateComponent: React.FC = () => {
-  const [selectedDate, setSelectedDate] = useState<Date>(new Date());
-  const [showCalendar, setShowCalendar] = useState<boolean>(false);
-  const [exchangeRate, setExchangeRate] = useState<number | null>(null);
-  const [selectedCurrency, setSelectedCurrency] = useState<Currency>(currencies[0]);
-  const [showCurrencyDropdown, setShowCurrencyDropdown] = useState<boolean>(false);
-  const [selectedTimeSlot, setSelectedTimeSlot] = useState<TimeSlot>(timeSlots[0]);
-  const [showTimeSlotDropdown, setShowTimeSlotDropdown] = useState<boolean>(false);
-  const [isLoading, setIsLoading] = useState<boolean>(false);
-  const [error, setError] = useState<string | null>(null);
-
+const ExchangeRatePage = (): React.ReactElement => {
   const navigate = useNavigate();
+  const [selectedCurrency, setSelectedCurrency] = useState<string>('USD')
 
-  useEffect(() => {
-    fetchExchangeRate();
-  }, [selectedCurrency]);
-
-  // 달력 선택
-  const handleDateSelect = (date: Date | undefined) => {
-    if (date) {
-      setSelectedDate(date);
-      setShowCalendar(false);
-    }
-  };
-
-  // 통화 선택
-  const handleCurrencySelect = (currency: Currency) => {
-    setSelectedCurrency(currency);
-    setShowCurrencyDropdown(false);
-  };
-
-  // 회차 선택
-  const handleTimeSlotSelect = (timeSlot: TimeSlot) => {
-    setSelectedTimeSlot(timeSlot);
-    setShowTimeSlotDropdown(false);
-  };
-
-  // 데이터 받아오는 로직 (백으로 요청)
-  const fetchExchangeRate = async () => {
-    setIsLoading(true);
-    setError(null);
-    try {
-      // 실제 API 호출로 대체해야 합니다.
-      // const response = await fetch(`your-api-endpoint?currency=${selectedCurrency.code}`);
-      // const data = await response.json();
-      // setExchangeRate(data.rate);
-
-      // 임시로 랜덤한 환율을 생성합니다.
-      const mockRate = Math.random() * 1000 + 500;
-      setExchangeRate(mockRate);
-    } catch (err) {
-      setError('환율 정보를 가져오는 데 실패했습니다. 다시 시도해 주세요.');
-    } finally {
-      setIsLoading(false);
-    }
-  };
-
-  // 환전하기 페이지로 이동
   const handleExchange = () => {
     navigate('/exchange');
   };
 
+  const handleCurrencyChange = (currency: string) => {
+    setSelectedCurrency(currency);
+  }
+
   return (
-    <div className="p-4 mt-5 max-w-sm mx-auto bg-white rounded-xl shadow-md space-y-4">
-      <h1 className="text-xl font-bold">환율 조회</h1>
-      <div className="space-y-4">
-        <div>
-          <h2 className="text-sm font-semibold mb-1">통화</h2>
-          <div className="relative">
-            <button
-              className="w-full flex items-center justify-between border rounded p-2"
-              onClick={() => setShowCurrencyDropdown(!showCurrencyDropdown)}
-            >
-              <span>{`${selectedCurrency.name} (${selectedCurrency.amount} ${selectedCurrency.code})`}</span>
-              <ChevronDown className="w-5 h-5" />
-            </button>
-            {showCurrencyDropdown && (
-              <div className="absolute z-20 w-full mt-1 bg-white border rounded shadow-lg max-h-60 overflow-auto">
-                {currencies.map((currency) => (
-                  <button
-                    key={currency.code}
-                    className="w-full text-left px-4 py-2 hover:bg-gray-100"
-                    onClick={() => handleCurrencySelect(currency)}
-                  >
-                    {`${currency.name} (${currency.amount} ${currency.code})`}
-                  </button>
-                ))}
-              </div>
-            )}
-          </div>
-        </div>
-        
-        {exchangeRate !== null && (
-          <div className="border rounded p-2">
-            <div className="text-sm text-gray-500">
-              현재 매매기준율
-            </div>
-            <div className="flex justify-between items-center">
-              <span>{`${selectedCurrency.amount} ${selectedCurrency.code}`}</span>
-              <span className="text-[#0046FF] font-bold">{exchangeRate.toFixed(2)}원</span>
-            </div>
-          </div>
-        )}
-        
-        <div>
-          <h2 className="text-sm font-semibold mb-1">날짜</h2>
-          <div className="relative">
-            <button
-              className="w-full flex items-center justify-between border rounded p-2"
-              onClick={() => setShowCalendar(!showCalendar)}
-            >
-              <span>{format(selectedDate, 'yyyy.MM.dd', { locale: ko })}</span>
-              <Calendar className="w-5 h-5" />
-            </button>
-            {showCalendar && (
-              <div className="absolute z-10 mt-1 bg-white border rounded shadow-lg">
-                <DayPicker
-                  mode="single"
-                  selected={selectedDate}
-                  onSelect={handleDateSelect}
-                  locale={ko}
-                />
-              </div>
-            )}
-          </div>
-        </div>
-        
-        <div>
-          <h2 className="text-sm font-semibold mb-1">회차</h2>
-          <div className="relative">
-            <button
-              className="w-full flex items-center justify-between border rounded p-2"
-              onClick={() => setShowTimeSlotDropdown(!showTimeSlotDropdown)}
-            >
-              <span>{selectedTimeSlot.name}</span>
-              <Clock className="w-5 h-5" />
-            </button>
-            {showTimeSlotDropdown && (
-              <div className="absolute z-20 w-full mt-1 bg-white border rounded shadow-lg">
-                {timeSlots.map((timeSlot) => (
-                  <button
-                    key={timeSlot.id}
-                    className="w-full text-left px-4 py-2 hover:bg-gray-100"
-                    onClick={() => handleTimeSlotSelect(timeSlot)}
-                  >
-                    {timeSlot.name}
-                  </button>
-                ))}
-              </div>
-            )}
-          </div>
-        </div>
-        
-        {error && <div className="text-red-500">{error}</div>}
-      </div>
-      <div className="flex space-x-2">
-        <button 
-          className="flex-1 bg-[#0046FF] text-white rounded py-2 disabled:bg-blue-300"
-          onClick={fetchExchangeRate}
-          disabled={isLoading}
-        >
-          {isLoading ? '조회 중...' : '조회하기'}
-        </button>
-        <button 
-          className="flex-1 bg-gray-200 rounded py-2"
-          onClick={handleExchange}
-        >
-          환전하기
-        </button>
+    <div className="p-4 mt-5 max-w-sm mx-auto bg-white rounded-xl shadow-md">
+      <h1 className="text-xl font-bold mb-4">환율 조회</h1>
+      <ExchangeRateInfo onExchangeClick={handleExchange} onCurrencyChange={handleCurrencyChange} />
+      <div className="mt-8">
+        {/* <h2 className="text-xl font-semibold mb-4">환율 변동 차트</h2> */}
+        <ExchangeRateChart currency={selectedCurrency} />
       </div>
     </div>
   );
 };
 
-export default ExchangeRateComponent;
+export default ExchangeRatePage;

--- a/frontend/soltravel/src/pages/exchange/SelectAccount.tsx
+++ b/frontend/soltravel/src/pages/exchange/SelectAccount.tsx
@@ -1,85 +1,124 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
 import { ChevronDown, ArrowDown } from 'lucide-react';
-import { useNavigate } from 'react-router-dom';
-
-// 백에서 받아올 데이터들 interface로 type 설정
-interface Account {
-  id: string;
-  type: string;
-  name: string;
-  accountNumber: string;
-  balance: number;
-  currency: string;
-}
+import { accountApi } from '../../api/account';
+import { AccountInfo } from '../../types/account';
 
 // 에시 데이터들, axios로 백에서 데이터 받아와야 함
-const SelectAccount: React.FC = () => {
-  const navigate = useNavigate();
-  const accounts: Account[] = [
-    {
-      id: '1',
-      type: '모임 통장',
-      name: '신한은행 모임 통장',
-      accountNumber: '신한 110-455-247307',
-      balance: 3000000,
-      currency: '원'
-    },
-    {
-      id: '2',
-      type: '트래블 박스',
-      name: '신한은행 외화 모임 통장',
-      accountNumber: '여행 예정일 : 25.01.13',
-      balance: 300000,
-      currency: '엔'
-    }
-  ];
+const SelectAccount = (): React.ReactElement => {
+  const [generalAccounts, setGeneralAccounts] = useState<AccountInfo[]>([]);
+  const [foreignAccounts, setForeignAccounts] = useState<AccountInfo[]>([]);
+  const [selectedAccount, setSelectedAccount] = useState<AccountInfo | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [isDropdownOpen, setIsDropdownOpen] = useState(false);
 
-//   해당 계좌에 Id가 있을 경우 사용
-//   const handleAccountSelect = (accountId: string) => {
-//     navigate(`/exchange`);
-//   };
+  const { userId } = useParams<{ userId: string }>();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const loadAccountData = async () => {
+      if (userId) {
+        try {
+          setIsLoading(true);
+          const [generalAccount, foreignAccount] = await Promise.all([
+            accountApi.fetchAccountInfo(userId),
+            accountApi.fetchForeignAccountInfo(userId)
+          ]);
+          setGeneralAccounts(generalAccount);
+          setForeignAccounts(foreignAccount);
+          if (generalAccount.length > 0) {
+            setSelectedAccount(generalAccount[0]);
+          }
+        } catch (error) {
+          setError('계좌 정보를 불러오는 데 실패했습니다.');
+          console.error('Error fetching account data:', error);
+        } finally {
+          setIsLoading(false);
+        }
+      }
+    };
+    loadAccountData();
+  }, [userId]);
+
+  const handleAccountSelect = (account: AccountInfo) => {
+    setSelectedAccount(account);
+    setIsDropdownOpen(false);
+  };
+  
+  const handleExchangeButton = () => {
+    if (selectedAccount && foreignAccounts.length > 0) {
+      navigate(`/exchange`);
+    }
+  };
+
+  if (isLoading) return <div>Loading...</div>;
+  if (error) return <div>{error}</div>;
+  if (generalAccounts.length === 0 && foreignAccounts.length === 0) return <div>계좌 정보를 찾을 수 없습니다.</div>;
 
   return (
     <div className="p-4 max-w-md mx-auto bg-gray-100 min-h-screen">
-    <h1 className="text-xl font-bold mb-4">모임 통장 선택</h1>
-      <div className="mb-4">
-        <button className="w-full flex items-center justify-between bg-white rounded-lg p-3 shadow">
-          <span>환전할 모임 통장 선택</span>
+      <h1 className="text-xl font-bold mb-4">모임 통장 선택</h1>
+      <div className="mb-4 relative">
+        <button 
+          className="w-full flex items-center justify-between bg-white rounded-lg p-3 shadow"
+          onClick={() => setIsDropdownOpen(!isDropdownOpen)}
+        >
+          <span>{selectedAccount ? selectedAccount.accountName : '환전할 모임 통장 선택'}</span>
           <ChevronDown className="w-5 h-5" />
         </button>
-      </div>
-      <div className="space-y-4">
-        <div className="bg-white rounded-lg p-4 shadow">
-          <h2 className="font-bold mb-2">모임 통장</h2>
-          <div className="flex items-center mb-2">
-            <div className="w-8 h-8 bg-[#0046FF] rounded-full mr-2"></div>
-            <div>
-              <p className="font-semibold">{accounts[0].name}</p>
-              <p className="text-sm text-gray-500">{accounts[0].accountNumber}</p>
-            </div>
+        {isDropdownOpen && (
+          <div className="absolute w-full mt-1 bg-white rounded-lg shadow-lg z-10">
+            {generalAccounts.map((account) => (
+              <button
+                key={account.accountNo}
+                className="w-full text-left p-3 hover:bg-gray-100"
+                onClick={() => handleAccountSelect(account)}
+              >
+                {account.accountName} - {account.accountNo}
+              </button>
+            ))}
           </div>
-          <p className="text-right font-bold">{accounts[0].balance.toLocaleString()} {accounts[0].currency}</p>
-        </div>
-        
-        <div className="flex justify-center items-center my-4">
-          <ArrowDown className="w-8 h-8 text-[#0046FF]" />
-        </div>
-        
-        <div className="bg-white rounded-lg p-4 shadow">
-          <h2 className="font-bold mb-2">트래블 박스</h2>
-          <div className="flex items-center mb-2">
-            <div className="w-8 h-8 bg-[#0046FF] rounded-full mr-2"></div>
-            <div>
-              <p className="font-semibold">{accounts[1].name}</p>
-              <p className="text-sm text-gray-500">{accounts[1].accountNumber}</p>
-            </div>
-          </div>
-          <p className="text-right font-bold">{accounts[1].balance.toLocaleString()} {accounts[1].currency}</p>
-        </div>
+        )}
       </div>
+      {selectedAccount && (
+        <div className="space-y-4">
+          <div className="bg-white rounded-lg p-4 shadow">
+            <h2 className="font-bold mb-2">일반모임통장</h2>
+            <div className="flex items-center mb-2">
+              <div className="w-8 h-8 bg-[#0046FF] rounded-full mr-2"></div>
+              <div>
+                <p className="font-semibold">{selectedAccount.accountName}</p>
+                <p className="text-sm text-gray-500">{selectedAccount.accountNo}</p>
+              </div>
+            </div>
+            <p className="text-right font-bold">{selectedAccount.accountBalance.toLocaleString()} KRW</p>
+          </div>
+
+          
+          <div className="flex justify-center items-center my-4">
+            <ArrowDown className="w-8 h-8 text-[#0046FF]" />
+          </div>
+          
+          {foreignAccounts.length > 0 && (
+            <div className="bg-white rounded-lg p-4 shadow">
+              <h2 className="font-bold mb-2">외화모임통장</h2>
+              <div className="flex items-center mb-2">
+                <div className="w-8 h-8 bg-[#0046FF] rounded-full mr-2"></div>
+                <div>
+                  <p className="font-semibold">{foreignAccounts[0].accountName}</p>
+                  <p className="text-sm text-gray-500">{foreignAccounts[0].accountNo}</p>
+                </div>
+              </div>
+              <p className="text-right font-bold">{foreignAccounts[0].accountBalance.toLocaleString()} {foreignAccounts[0].currency}</p>
+            </div>
+          )}
+        </div>
+      )}
       <button
         className="w-full bg-[#0046FF] text-white py-3 rounded-lg mt-4"
-        // onClick={() => handleAccountSelect(accounts[0].id)}
+        onClick={handleExchangeButton}
+        disabled={!selectedAccount || foreignAccounts.length === 0}
       >
         환전하기
       </button>

--- a/frontend/soltravel/src/pages/user/SignUp.tsx
+++ b/frontend/soltravel/src/pages/user/SignUp.tsx
@@ -1,21 +1,88 @@
 import { useState } from "react";
 import { useNavigate } from "react-router";
+import { userApi } from "../../api/user";
 import UserForm from "../../components/user/UserForm";
 
+interface InputState {
+  email: string;
+  password: string;
+  confirmPassword: string;
+  name: string;
+  birthday: string;
+  phone: string;
+  address: string;
+  verificationCode?: string;
+}
 
 const SignUp = () => {
   const navigate = useNavigate();
+  const [isFormValid, setIsFormValid] = useState(false);
+
+  const [inputs, setInputs] = useState<InputState>({
+    email: "",
+    password: "",
+    confirmPassword: "",
+    name: "",
+    birthday: "",
+    phone: "",
+    address: "",
+    // verificationCode: "",
+  });
+
+  const formatBirthday = (birthday: string): string => {
+    return `${birthday.slice(0, 4)}-${birthday.slice(4, 6)}-${birthday.slice(6, 8)}`;
+  };
+
+  const handleSignUp = async () => {
+    const formData = new FormData();
+
+    formData.append(
+      "request",
+      new Blob(
+        [
+          JSON.stringify({
+            name: inputs.name,
+            email: inputs.email,
+            password: inputs.password,
+            phone: inputs.phone,
+            address: inputs.address,
+            birth: formatBirthday(inputs.birthday),
+          }),
+        ],
+        { type: "application/json" }
+      )
+    );
+
+    try {
+      // 첫 번째 API 호출: 회원가입
+      const signUpResponse = await userApi.fetchSignUp(formData);
+
+      // 두 번째 API 호출: 알림 구독
+      const notificationResponse = await userApi.fetchNotificationSubscribe();
+
+      // 두 API 호출 모두 성공했는지 확인
+      if (signUpResponse && notificationResponse) {
+        console.log("회원가입 성공");
+      } else {
+        console.error("회원가입 오류: API 호출 실패");
+      }
+    } catch (error) {
+      console.error("회원가입 오류", error);
+    }
+  };
 
   return (
     <div className="w-full h-screen p-5 bg-[#EFEFF5]">
       <div className="h-full flex flex-col justify-center space-y-8">
-        <p className="text-2xl font-bold">All-In-One 뱅크 회원가입</p>
-        <UserForm />
+        <p className="text-xl font-bold">회원가입</p>
+        <UserForm inputs={inputs} setInputs={setInputs} setIsFormValid={setIsFormValid} />
         <button
           onClick={() => {
-            navigate("/");
+            handleSignUp();
           }}
-          className="w-full h-24 rounded-md bg-[#0046FF] font-bold text-white text-sm">
+          className={`w-full h-24 rounded-md font-bold text-white text-sm ${!isFormValid ? "bg-[#c5cde2]" : "bg-[#0046FF]"}`}
+          disabled={!isFormValid}
+        >
           가입
         </button>
         <div className="w-full h-20 flex items-center justify-center space-x-2">
@@ -24,7 +91,8 @@ const SignUp = () => {
             onClick={() => {
               navigate("/login");
             }}
-            className="text-[#0046FF] font-bold">
+            className="text-[#0046FF] font-bold"
+          >
             로그인
           </button>
         </div>

--- a/frontend/soltravel/src/pages/viewaccount/ViewAccount.tsx
+++ b/frontend/soltravel/src/pages/viewaccount/ViewAccount.tsx
@@ -11,7 +11,7 @@ const GroupAccountPage = (): React.ReactElement => {
 
   return (
     <div className='px-4 mx-auto container'>
-      <h1 className='mb-4 text-2xl font-bold'>계좌 정보</h1>
+      <h1 className='mt-4 mb-4 text-2xl font-bold'>계좌 정보</h1>
       <GroupAccount />
     </div>
   );

--- a/frontend/soltravel/src/redux/accountSlice.ts
+++ b/frontend/soltravel/src/redux/accountSlice.ts
@@ -1,28 +1,27 @@
 import { createSlice } from "@reduxjs/toolkit";
 import type { PayloadAction } from "@reduxjs/toolkit";
-import { MeetingAccountListDetail, MeetingAccountDetail } from "../types/account";
+import { MeetingAccountListDetail, GeneralMeetingAccountDetail } from "../types/account";
 
 export interface AccountState {
   isKeyboard: boolean;
   accountPassword: string;
   meetingAccountList: Array<MeetingAccountListDetail>;
-  meetingAccountDetail: MeetingAccountDetail;
+  generalMeetingAccountDetail: GeneralMeetingAccountDetail;
 }
 
 const initialState: AccountState = {
   isKeyboard: false,
   accountPassword: "",
   meetingAccountList: [],
-  meetingAccountDetail: {
-    meetingAccountName: "",
-    meetingAccountIcon: "",
-    meetingAccountUserName: "",
-    meetingAccountUserResidentNumber: "",
-    meetingAccountPassword: "",
-    meetingAccountMemberList: [],
+  generalMeetingAccountDetail: {
+    generalMeetingAccountName: "",
+    generalMeetingAccountIcon: "",
+    generalMeetingAccountUserName: "",
+    generalMeetingAccountUserResidentNumber: "",
+    generalMeetingAccountPassword: "",
+    generalMeetingAccountMemberList: [],
   },
 };
-
 
 export const userSilce = createSlice({
   name: "account",
@@ -37,9 +36,12 @@ export const userSilce = createSlice({
     editMeetingAccountList: (state, action: PayloadAction<Array<MeetingAccountListDetail>>) => {
       state.meetingAccountList = action.payload;
     },
+    editGeneralMeetingAccountList: (state, action: PayloadAction<GeneralMeetingAccountDetail>) => {
+      state.generalMeetingAccountDetail = action.payload;
+    },
   },
 });
 
-export const { setIsKeyboard, setAccountPassword, editMeetingAccountList } = userSilce.actions;
+export const { setIsKeyboard, setAccountPassword, editMeetingAccountList, editGeneralMeetingAccountList } = userSilce.actions;
 
 export default userSilce.reducer;

--- a/frontend/soltravel/src/types/account.ts
+++ b/frontend/soltravel/src/types/account.ts
@@ -52,12 +52,19 @@ export interface MeetingAccountListDetail {
   };
 }
 
-// 모임통장 개설 정보
-export interface MeetingAccountDetail {
-  meetingAccountName: string;
-  meetingAccountIcon: string;
-  meetingAccountUserName: string;
-  meetingAccountUserResidentNumber: string;
-  meetingAccountPassword: string;
-  meetingAccountMemberList: Array<string>;
+// 일반모임통장 개설 정보
+export interface GeneralMeetingAccountDetail {
+  generalMeetingAccountName: string;
+  generalMeetingAccountIcon: string;
+  generalMeetingAccountUserName: string;
+  generalMeetingAccountUserResidentNumber: string;
+  generalMeetingAccountPassword: string;
+  generalMeetingAccountMemberList: Array<string>;
 }
+
+// 모임통장 모임종류 아이콘 
+export const meetingAccountIconList: Array<{text: string, value: string}> = [
+  { text: "선택안함", value: "none" },
+  { text: "여행", value: "airplane" },
+  { text: "학교", value: "school" },
+];

--- a/frontend/soltravel/src/types/exchange.ts
+++ b/frontend/soltravel/src/types/exchange.ts
@@ -1,0 +1,71 @@
+// 환율 타입
+export interface ExchangeRateInfo {
+  currencyCode: string;
+  exchangeRate: number;
+  exchangeMin: number;
+  created: string;
+}
+
+// 환율 그래프를 위한 타입
+export interface ExchangeRateHistoryRequest {
+  currencyCode: string;
+  startDate: string;
+  endDate: string;
+}
+
+export interface ExchangeRateHistoryResponse {
+  id: number;
+  postAt: string;
+  dealBasR: number;
+  ttb: number;
+  tts: number;
+  cashBuying: number;
+  cashSelling: number;
+  tcBuying: number;
+}
+
+// 환전 진행 관련 요청 / 응답
+export interface ExchangeRequest {
+  accountid: number;
+  accountNo: string;
+  exchangeCurrency: string;
+  exchangeAmount: number;
+  exchangeRate: number;
+}
+
+export interface ExchangeResponse {
+  exchangeCurrencyDto: {
+    amount: number;
+    exchangeRate: number;
+    currency: string;
+  },
+  accountInfoDto: {
+    accountNo: string;
+    accountId: number;
+    amount: number;
+    balance: number;
+  },
+  executed_at: string;
+}
+
+// 통화 종류
+export const currencyNames: { [key: string]: string } = {
+  USD: '미국 달러',
+  JPY: '일본 엔',
+  EUR: '유로',
+  GBP: '영국 파운드',
+  CHF: '스위스 프랑',
+  CAD: '캐나다 달러',
+  CNY: '중국 위안',
+};
+
+// 통화 종류 목록
+export const currencyTypeList: Array<{text: string, value: string}> = [
+  { text: "USD(미국/$)", value: "USD" },
+  { text: "JPY(일본/¥)", value: "JPY" },
+  { text: "EUR(유로/€)", value: "EUR" },
+  { text: "GBP(영국/£)", value: "GBP" },
+  { text: "CHF(스위스/₣)", value: "CHF" },
+  { text: "CAD(캐나다/$)", value: "CAD" },
+  { text: "CNY(중국/¥)", value: "CNY" },
+];


### PR DESCRIPTION
## 개요
계좌 개설 시 모바일에서 주민등록번호 입력 후 보안 키패드가 나왔음에도 모바일 자체의 키패트가 여전히 남아있는 문제 해결
일반모임통장 개설 시 모임종류 선택으로 수정
메인페이지에서 모임통장 신청하기 버튼 클릭 시, 입출금 통장 개설이 아니라 모임통장 개설로 연결되도록 라우팅
해외여행 올인원 모임통장 안내페이지 디자인
일반모임통장 개설 시, 모임원 추가 디자인
일반모임통장 입력 데이터는 store 저장한 뒤 외화모임통장 개설 화면으로 전환
외화모임통장 개설 화면 디자인
추후 구현 예정(일반모임통장 모임원 추가 시, 이메일로 입력 후 해당 사용자명 받아오는 로직 구현 필요, 모임통장 개설 완료 화면 추가 디자인, 희망 환율 소숫점 입력 및 숫자만 입력가능하게 수정, 정보 확인 화면 추가)
환율 및 환전 페이지 구현

Resolves: #(Isuue Number)

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [x] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## 결과화면
<img width="319" alt="스크린샷_2024-08-29_오전_12 26 54" src="https://github.com/user-attachments/assets/5ea0b026-4eaf-43f3-9dd0-26a000a9ef7a">

![Animation2 (1)](https://github.com/user-attachments/assets/1e499ed9-0368-4bc9-9792-0f91852a4593)
